### PR TITLE
Replace dot with dash in slugs

### DIFF
--- a/jekyll/_includes/comments.html
+++ b/jekyll/_includes/comments.html
@@ -1,5 +1,5 @@
 {% capture default_slug %}{{ page.slug | default: (page.title | slugify) }}{% endcapture %}
-{% capture slug %}{{ (page.slug | fallback: default_slug) | downcase }}{% endcapture %}
+{% capture slug %}{{ (page.slug | fallback: default_slug) | downcase | replace: '.', '-' }}{% endcapture %}
 {% assign comments_map = site.data.comments[slug] %}
 {% assign comments = site.emptyArray %}
 {% for comment in comments_map %}


### PR DESCRIPTION
The `.` character is allowed in slugs, but Jekyll's array reference into data, `site.data.comments[slug]`, doesn't like it if the `slug` has a `.` character in it. So this replaces the dot with a dash. I'll have to make a corresponding change to https://github.com/damieng/jekyll-blog-comments-azure/blob/master/JekyllBlogCommentsAzure/PostCommentToPullRequestFunction.cs