### PR TITLE
Post the comment host website URL

### DIFF
--- a/jekyll/_includes/comment-new.html
+++ b/jekyll/_includes/comment-new.html
@@ -2,6 +2,7 @@
 <form action="/fake" method="post" id="commentform" class="form-horizontal">
   <input name="redirect" type="hidden" value="/thanks">
   <input name="post_id" type="hidden" value="{{ slug }}">
+  <input name="comment-site" type="hidden" value="{{ site.url }}">
   <div id="commenttext">
     <textarea name="comment" id="comment" placeholder="Continue the discussion."></textarea>
   </div>


### PR DESCRIPTION
This allows the jekyll comment receiver to validate that the incoming comment is being posted to the correct receiver. See https://github.com/damieng/jekyll-blog-comments-azure/pull/8 for more information.