### PR TITLE
Disable the input fields after submitting

### DIFF
--- a/jekyll/_includes/comment-new.html
+++ b/jekyll/_includes/comment-new.html
@@ -40,10 +40,9 @@
       form.action = '{{ site.comments.receiver }}'
       button.innerText = 'Posting...'
       button.disabled = true
+      form.submit()
       var fields = document.getElementById('commentfields')                                         
       fields.disabled = true
-      form.submit()
     }
   </script>
-</form>
 <div id="commentstatus" style="clear:both" class="status"></div>


### PR DESCRIPTION
If the fields are disabled before submitting the form, the browser will not post their values since they will have `disabled` attributes (see ref). Moved the disable posts logic after the submission to prevent this.

ref: https://www.w3.org/TR/html5/forms.html#constructing-the-form-data-set